### PR TITLE
Update Vale to 1.0.5

### DIFF
--- a/registry/theqtcompany.vale/extension.json
+++ b/registry/theqtcompany.vale/extension.json
@@ -15,6 +15,46 @@
     },
     "latest": "0.7.0",
     "versions": {
+        "1.0.5": {
+            "sources": [
+                {
+                    "url": "https://github.com/qt-creator/plugin-vale-languageserver/releases/download/v1.0.5/ValeLS.zip",
+                    "sha256": "4d8d5cc26c01ad53d0b8f30072a88934964a7b7856c3c51240106341b6b7e8cf"
+                }
+            ],
+            "metadata": {
+                "Id": "vale",
+                "Url": "https://www.qt.io",
+                "Name": "Vale Language Server",
+                "Tags": [
+                    "language server",
+                    "Vale",
+                    "ValeLS",
+                    "Qt"
+                ],
+                "Vendor": "The Qt Company",
+                "License": "GPL",
+                "Version": "1.0.5",
+                "Category": "Language Server",
+                "VendorId": "theqtcompany",
+                "Copyright": "(C) The Qt Company 2024",
+                "Type": "Script",
+                "Languages": [
+                    "en",
+                    "de"
+                ],
+                "Description": "Provides an integration of the Vale language server",
+                "Dependencies": [
+                    {
+                        "Id": "lualanguageclient",
+                        "Version": "15.0.0"
+                    }
+                ],
+                "Experimental": true,
+                "CompatVersion": "1.0.0",
+                "DisabledByDefault": false
+            }
+        },
         "1.0.4": {
             "sources": [
                 {


### PR DESCRIPTION
Updated Vale to 1.0.5

## Checklist

- [x] I have run `npm run all` to validate my changes
- [x] I have made sure my commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
- [x] I have read and I agree with the [Qt Creator Extensions Store Publisher Terms](https://github.com/qt-creator/extension-registry/blob/main/documentation/publisher-terms.pdf)
